### PR TITLE
Fixes #103

### DIFF
--- a/lib/Nipe/Engine/Start.pm
+++ b/lib/Nipe/Engine/Start.pm
@@ -8,19 +8,10 @@ package Nipe::Engine::Start {
 		my $dnsPort      = "9061";
 		my $transferPort = "9051";
 		my @table        = ("nat", "filter");
-		my $network      = "10.66.0.0/255.255.0.0";
+		my $network      = "127.192.0.0/10";  # default Tor VirtualAddrNetwork
 		my $startTor     = "systemctl start tor";
 
-		if ($device{distribution} eq "void") {
-			$startTor = "sv start tor > /dev/null";
-		}
-
-		elsif (-e "/etc/init.d/tor") {
-			$startTor = "/etc/init.d/tor start > /dev/null";
-		}
-
-		system ("tor -f .configs/$device{distribution}-torrc > /dev/null");
-		system ($startTor);
+		system ($device{startTor});
 
 		foreach my $table (@table) {
 			my $target = "ACCEPT";

--- a/lib/Nipe/Engine/Stop.pm
+++ b/lib/Nipe/Engine/Stop.pm
@@ -6,22 +6,13 @@ package Nipe::Engine::Stop {
 	sub new {
 		my %device  = Nipe::Utils::Device -> new();
 		my @table   = ("nat", "filter");
-		my $stopTor = "systemctl stop tor";
-
-		if ($device{distribution} eq "void") {
-			$stopTor = "sv stop tor > /dev/null";
-		}
 
 		foreach my $table (@table) {
 			system ("iptables -t $table -F OUTPUT");
 			system ("iptables -t $table -F OUTPUT");
 		}
 
-		if (-e "/etc/init.d/tor") {
-			$stopTor = "/etc/init.d/tor stop > /dev/null";
-		}
-
-		system ($stopTor);
+		system ($device{stopTor});
 
 		return 1;
 	}

--- a/lib/Nipe/Utils/Device.pm
+++ b/lib/Nipe/Utils/Device.pm
@@ -10,7 +10,7 @@ package Nipe::Utils::Device {
 		my $id_distro = $config -> param("ID");
 
 		my %device = (
-			"username" => "",
+			"username" => "tor",
 			"distribution"  => "",
 			"startTor" => "systemctl start tor > /dev/null",
 			"stopTor" => "systemctl stop tor > /dev/null",
@@ -27,12 +27,10 @@ package Nipe::Utils::Device {
 		}
 
 		elsif (($id_like =~ /[A,a]rch/) || ($id_like =~ /[C,c]entos/) || ($id_distro =~ /[A,a]rch/) || ($id_distro =~ /[C,c]entos/)) {
-			$device{username} = "tor";
 			$device{distribution} = "arch";
 		}
 
 		elsif ($id_distro =~ /[V,v]oid/) {
-			$device{username} = "tor";
 			$device{distribution} = "void";
 			$device{startTor} = "sv start tor";
 			$device{stopTor} = "sv stop tor";

--- a/lib/Nipe/Utils/Device.pm
+++ b/lib/Nipe/Utils/Device.pm
@@ -1,4 +1,5 @@
 package Nipe::Utils::Device {
+
 	use strict;
 	use warnings;
 	use Config::Simple;
@@ -10,8 +11,15 @@ package Nipe::Utils::Device {
 
 		my %device = (
 			"username" => "",
-			"distribution"  => ""
+			"distribution"  => "",
+			"startTor" => "systemctl start tor > /dev/null",
+			"stopTor" => "systemctl stop tor > /dev/null",
 		);
+
+		if (-e "/etc/init.d/tor") {
+			$device{startTor} = "/etc/init.d/tor start > /dev/null";
+			$device{stopTor} = "/etc/init.d/tor stop > /dev/null";
+		}
 
 		if (($id_like =~ /[F,f]edora/) || ($id_distro =~ /[F,f]edora/)) {
 			$device{username} = "toranon";
@@ -26,6 +34,8 @@ package Nipe::Utils::Device {
 		elsif ($id_distro =~ /[V,v]oid/) {
 			$device{username} = "tor";
 			$device{distribution} = "void";
+			$device{startTor} = "sv start tor";
+			$device{stopTor} = "sv stop tor";
 		}
 
 		else {

--- a/lib/Nipe/Utils/Install.pm
+++ b/lib/Nipe/Utils/Install.pm
@@ -53,8 +53,14 @@ package Nipe::Utils::Install {
 			system ("xbps-install -y tor iptables");
 		}
 
-		else {
+		elsif ($device{distribution} eq "arch") {
 			system ("pacman -S --noconfirm tor iptables");
+		}
+
+		else {
+			print STDERR "Unknown distribution.\n";
+			print STDERR "Install tor and iptables using your package manager.\n";
+			die;
 		}
 
 		system ($device{stopTor});

--- a/lib/Nipe/Utils/Install.pm
+++ b/lib/Nipe/Utils/Install.pm
@@ -7,7 +7,6 @@ package Nipe::Utils::Install {
 
 	sub new {
 		my %device  = Nipe::Utils::Device -> new();
-		my $stopTor = "systemctl stop tor";
 		my $nipeTorConfig = "/etc/torrc.d/nipe";
 
 		if (! -d dirname ($nipeTorConfig)) {
@@ -18,11 +17,25 @@ package Nipe::Utils::Install {
 			copy ("torrc.d/nipe", $nipeTorConfig) or die "Copy failed: $!";
 		}
 
+		if (! -d dirname ($nipeTorConfig)) {
+			mkdir dirname ($nipeTorConfig), 0755;
+		}
+
 		open (FILE, "+<", "/etc/tor/torrc");
 		if (not grep{ /^%include \/etc\/torrc\.d\/nipe$/ } <FILE>) {
 			print FILE "%include /etc/torrc.d/nipe\n";
 		}
 		close FILE;
+
+		# find out if AppArmor is enabled (returns Y if true)
+		open FILE, "<", "/sys/module/apparmor/parameters/enabled";
+		chomp(my $apparmor = <FILE>);
+		close FILE;
+		if ( $apparmor eq "Y" ) {
+			open APPARMOR, ">", "/etc/apparmor.d/local/system_tor";
+			print APPARMOR "/etc/torrc.d/nipe r,\n";
+			close APPARMOR;
+		}
 
 		if ($device{distribution} eq "debian") {
 			system ("apt-get install -y tor iptables");

--- a/nipe.pl
+++ b/nipe.pl
@@ -14,7 +14,7 @@ use Nipe::Utils::Install;
 
 sub main {
 	my $argument = $ARGV[0];
-	
+
 	if ($argument) {
 		die "Nipe must be run as root.\n" if $> != 0;
 

--- a/torrc.d/nipe
+++ b/torrc.d/nipe
@@ -1,0 +1,3 @@
+TransPort 9051 IsolateClientAddr IsolateClientProtocol IsolateDestAddr IsolateDestPort
+DNSPort   9061
+AutomapHostsOnResolve 1


### PR DESCRIPTION
### What was a problem?

The problem was reported and discussed in ticket #103 

Particularly, in [my comment](https://github.com/GouveaHeitor/nipe/issues/103#issuecomment-663824721).

### How this PR fixes the problem?

- put Nipe-specific Tor settings into  **/etc/torrc.d/nipe** file
- include **/etc/torrc.d/nipe file** into **/etc/tor/torrc** while running `nipe.pl install`
- do not run custom Tor process, but use Tor system service instead (see **Case 2** of  [my comment](https://github.com/GouveaHeitor/nipe/issues/103#issuecomment-663824721) )


### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed (soon)
- [x] Coding style (indentation, etc)

### Additional Comments

- use "127.192.0.0/10" instead of "10.66.0.0/255.255.0.0".  It's default Tor VirtualAddrNetwork
  - see `man 1 tor` for details
- move **startTor** and **stopTor** commands to  lib/Nipe/Utils/Device.pm
  - adjust them according to distribution in a single place in Device.pm
- do not get Arch Linux as default distribution(and pacman as well) but show error message instead and recommend to  install dependencies(tor, iptables) manualy.
