### PR TITLE
Remove obsolete options, update API check JSON parsing

### DIFF
--- a/.configs/arch-torrc
+++ b/.configs/arch-torrc
@@ -14,9 +14,7 @@ RunAsDaemon 1
 
 # ClientOnly 1
 # TransPort 9051
-# TransListenAddress 127.0.0.1
 DNSPort   9061
-DNSListenAddress 127.0.0.1
 
 # VirtualAddrNetwork 10.66.0.0/255.255.0.0
 # AutomapHostsOnResolve 1

--- a/.configs/centos-torrc
+++ b/.configs/centos-torrc
@@ -14,9 +14,7 @@ Log notice file /var/log/tor/log
 
 ClientOnly 1
 TransPort 9051
-TransListenAddress 127.0.0.1
 DNSPort   9061
-DNSListenAddress 127.0.0.1
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0
 AutomapHostsOnResolve 1

--- a/.configs/debian-torrc
+++ b/.configs/debian-torrc
@@ -14,9 +14,7 @@ Log notice file /var/log/tor/log
 
 ClientOnly 1
 TransPort 9051
-TransListenAddress 127.0.0.1
 DNSPort   9061
-DNSListenAddress 127.0.0.1
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0
 AutomapHostsOnResolve 1

--- a/.configs/fedora-torrc
+++ b/.configs/fedora-torrc
@@ -14,9 +14,7 @@ Log notice file /var/log/tor/log
 
 ClientOnly 1
 TransPort 9051
-TransListenAddress 127.0.0.1
 DNSPort   9061
-DNSListenAddress 127.0.0.1
 
 VirtualAddrNetwork 10.66.0.0/255.255.0.0
 AutomapHostsOnResolve 1

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ['https://heitorgouvea.me/donate']

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@ License
 ==============
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2021 | Heitor Gouvêa
+Copyright (c) 2015 - 2022 | Heitor Gouvêa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All non-local UDP/ICMP traffic is also blocked by the Tor project.
 
 - Your contributions and suggestions are heartily ♥ welcome. [See here the contribution guidelines.](/.github/CONTRIBUTING.md) Please, report bugs via [issues page](https://github.com/htrgouvea/nipe/issues) and for security issues, see here the [security policy.](/SECURITY.md) (✿ ◕‿◕) This project follows the best practices defined by this [style guide](https://heitorgouvea.me/projects/perl-style-guide).
 
-If you are interested in providing financial support to this project, please visit: [heitorgouvea.me/donate](https://heitorgouvea.me/donate)
+- If you are interested in providing financial support to this project, please visit: [heitorgouvea.me/donate](https://heitorgouvea.me/donate)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ All non-local UDP/ICMP traffic is also blocked by the Tor project.
 
 - Your contributions and suggestions are heartily ♥ welcome. [See here the contribution guidelines.](/.github/CONTRIBUTING.md) Please, report bugs via [issues page](https://github.com/htrgouvea/nipe/issues) and for security issues, see here the [security policy.](/SECURITY.md) (✿ ◕‿◕) This project follows the best practices defined by this [style guide](https://heitorgouvea.me/projects/perl-style-guide).
 
+If you are interested in providing financial support to this project, please visit: [heitorgouvea.me/donate](https://heitorgouvea.me/donate)
+
 ---
 
 ### License

--- a/lib/Nipe/Utils/Status.pm
+++ b/lib/Nipe/Utils/Status.pm
@@ -12,7 +12,7 @@ package Nipe::Utils::Status {
 			my $data = decode_json ($request -> {content});
 
 			my $checkIp  = $data -> {"IP"};
-			my $checkTor = $data -> {"IsTor"} ? "activated" : "disabled";
+			my $checkTor = $data -> {"IsTor"} ? "true" : "false";
 
 			return "\n\r[+] Status: $checkTor. \n\r[+] Ip: $checkIp\n\n";
 		}


### PR DESCRIPTION
### What was a problem?

Remove obsolete options in torrc:
```
[warn] Skipping obsolete configuration option "TransListenAddress".
[warn] Skipping obsolete configuration option "DNSListenAddress".
```

Update API check JSON parsing:
```
$ curl https://check.torproject.org/api/ip
{"IsTor":false,"IP":"xx.xx.xx.xx"}

$ curl --socks5-hostname 127.0.0.1:9050 https://check.torproject.org/api/ip
{"IsTor":true,"IP":"yy.yy.yy.yy"}
```


### How this PR fixes the problem?

Updated torrc and JSON parsing


### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed (soon)
- [x] Coding style (indentation, etc)
