### PR TITLE
feat(tests): add more unit tests and update relative path

### DIFF
--- a/tests/Device.t
+++ b/tests/Device.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use Config::Simple;
+use lib '../lib/';
+use Nipe::Utils::Device;
+
+my $mock = Test::MockModule -> new('Config::Simple');
+
+my %distributions = (
+    'debian' => {
+        'ID'          => 'debian',
+        'ID_LIKE'     => '',
+        'username'    => 'debian-tor',
+        'distribution'=> 'debian'
+    },
+    'fedora' => {
+        'ID'          => 'fedora',
+        'ID_LIKE'     => 'fedora',
+        'username'    => 'toranon',
+        'distribution'=> 'fedora'
+    },
+    'arch' => {
+        'ID'          => 'arch',
+        'ID_LIKE'     => 'arch',
+        'username'    => 'tor',
+        'distribution'=> 'arch'
+    },
+    'centos' => {
+        'ID'          => 'centos',
+        'ID_LIKE'     => 'centos',
+        'username'    => 'tor',
+        'distribution'=> 'arch'
+    },
+    'void' => {
+        'ID'          => 'void',
+        'ID_LIKE'     => '',
+        'username'    => 'tor',
+        'distribution'=> 'void'
+    },
+    'opensuse' => {
+        'ID'          => 'opensuse',
+        'ID_LIKE'     => 'suse',
+        'username'    => 'tor',
+        'distribution'=> 'opensuse'
+    }
+);
+
+foreach my $distro (keys %distributions) {
+    $mock -> mock('new', sub { 
+        my $class = shift;
+        return bless { 
+            'ID' => $distributions{$distro}{'ID'},
+            'ID_LIKE' => $distributions{$distro}{'ID_LIKE'}
+        }, $class;
+    });
+
+    $mock -> mock('param', sub {
+        my ($self, $param) = @_;
+        return $self -> {$param};
+    });
+
+    my %device = Nipe::Utils::Device -> new();
+    
+    is($device{username}, $distributions{$distro}{'username'}, "Username is correct for $distro");
+    is($device{distribution}, $distributions{$distro}{'distribution'}, "Distribution is correct for $distro");
+}
+
+done_testing();

--- a/tests/Helper.t
+++ b/tests/Helper.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib '../lib/';
 use Nipe::Utils::Helper;
 
 {

--- a/tests/Install.t
+++ b/tests/Install.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+use lib '../lib/';
+
+my $mock_install = Test::MockObject -> new();
+$mock_install -> fake_module(
+    'Nipe::Utils::Install',
+    new => sub {
+        my ($class) = @_;
+        my $self = bless {}, $class;
+        
+        my $distro = $ENV{DISTRO} || 'debian';
+        
+        my %install = (
+            debian   => "apt-get install -y tor iptables",
+            fedora   => "dnf install -y tor iptables",
+            centos   => "yum -y install epel-release tor iptables",
+            void     => "xbps-install -y tor iptables",
+            arch     => "pacman -S --noconfirm tor iptables",
+            opensuse => "zypper install -y tor iptables"
+        );
+
+        if (exists $install{$distro}) {
+            pass("Correct install command would be executed for $distro: $install{$distro}");
+            return 1;  
+        } else {
+            pass("Unknown distribution: $distro");
+            return 0;
+        }
+    }
+);
+
+my @distributions = qw(debian fedora centos void arch opensuse);
+
+foreach my $distro (@distributions) {
+    local $ENV{DISTRO} = $distro;
+    my $install = Nipe::Utils::Install -> new();
+    is($install, 1, "Install command executed correctly for $distro");
+}
+
+{
+    local $ENV{DISTRO} = 'unknown';
+    my $install = Nipe::Utils::Install -> new();
+    is($install, 0, "Install returns 0 for unknown distribution");
+}
+
+done_testing();

--- a/tests/Restart.t
+++ b/tests/Restart.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use lib '../lib/';
+use Nipe::Engine::Restart;
+use Nipe::Engine::Stop;
+use Nipe::Engine::Start;
+
+my $mock_stop = Test::MockModule -> new('Nipe::Engine::Stop');
+$mock_stop -> mock('new', sub {
+    my $self = bless {}, 'Nipe::Engine::Stop';
+    return 1;  
+});
+
+my $mock_start = Test::MockModule -> new('Nipe::Engine::Start');
+$mock_start -> mock('new', sub {
+    my $self = bless {}, 'Nipe::Engine::Start';
+    return 1;  
+});
+
+my $restart = Nipe::Engine::Restart -> new();
+ok($restart, 'Restart module initialized correctly');
+
+$mock_stop -> unmock_all();
+$mock_start -> unmock_all();
+
+done_testing();

--- a/tests/Start.t
+++ b/tests/Start.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use lib '../lib/';
+use Nipe::Engine::Start;
+
+my $mock_device = Test::MockModule -> new('Nipe::Utils::Device');
+$mock_device -> mock('new', sub {
+    return (
+        'distribution' => 'debian',
+        'username' => 'debian-tor'
+    );
+});
+
+my $mock_system = Test::MockModule -> new('Nipe::Engine::Start');
+$mock_system -> mock('system', sub {
+    my ($command) = @_;
+    return 0;
+});
+
+my $start = Nipe::Engine::Start -> new();
+ok(defined $start, 'Start module initialized');
+
+$mock_device -> unmock_all();
+$mock_system -> unmock_all();
+
+done_testing();

--- a/tests/Status.t
+++ b/tests/Status.t
@@ -1,0 +1,62 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use JSON;
+use lib '../lib/';
+use Nipe::Utils::Status;
+
+sub normalize_whitespace {
+    my ($str) = @_;
+    $str =~ s/^\s+|\s+$//g; 
+    $str =~ s/\s+/ /g;       
+    return $str;
+}
+
+my $mock_http = Test::MockModule -> new('HTTP::Tiny');
+
+subtest 'Successful connection' => sub {
+    $mock_http -> mock('get', sub {
+        return {
+            status => 200,
+            content => encode_json({
+                IP => '1.2.3.4',
+                IsTor => JSON::true
+            })
+        };
+    });
+
+    my $status = Nipe::Utils::Status -> new();
+    my $expected = "[+] Status: true [+] Ip: 1.2.3.4";
+    is(normalize_whitespace($status), $expected, 'Status output is correct for successful Tor connection');
+};
+
+subtest 'Unsuccessful connection' => sub {
+    $mock_http -> mock('get', sub {
+        return { status => 500 };
+    });
+
+    my $status = Nipe::Utils::Status -> new();
+    my $expected = "[!] ERROR: sorry, it was not possible to establish a connection to the server.";
+    is(normalize_whitespace($status), $expected, 'Error message is correct for unsuccessful connection');
+};
+
+subtest 'Non-Tor connection' => sub {
+    $mock_http -> mock('get', sub {
+        return {
+            status => 200,
+            content => encode_json({
+                IP => '5.6.7.8',
+                IsTor => JSON::false
+            })
+        };
+    });
+
+    my $status = Nipe::Utils::Status -> new();
+    my $expected = "[+] Status: false [+] Ip: 5.6.7.8";
+    is(normalize_whitespace($status), $expected, 'Status output is correct for non-Tor connection');
+};
+
+done_testing();

--- a/tests/Stop.t
+++ b/tests/Stop.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+use lib '../lib/';
+use Nipe::Engine::Stop;
+use Nipe::Utils::Device;
+
+my $mock_device = Test::MockModule -> new('Nipe::Utils::Device');
+$mock_device -> mock('new', sub {
+    return (
+        'distribution' => 'debian', 
+        'username' => 'debian-tor'
+    );
+});
+
+my $mock_stop = Test::MockModule -> new('Nipe::Engine::Stop');
+$mock_stop -> mock('system', sub { return 1; });
+
+{
+    my $stop = Nipe::Engine::Stop -> new();
+    ok($stop, 'Stop module initialized correctly');
+}
+
+$mock_device -> unmock_all();
+$mock_stop -> unmock_all();
+
+done_testing();


### PR DESCRIPTION
- updated Helper.t to use the relative path '../lib/' for loading modules
- added unit tests for the following modules:
  - Device.pm
  - Install.pm
  - Status.pm 
  - Restart.pm 
  - Start.pm 
  - Stop.pm