### PR TITLE
feat(docker): update Dockerfile to make nipe work in containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,25 @@ FROM ubuntu:latest
 COPY . /usr/src/nipe
 WORKDIR /usr/src/nipe
 
-EXPOSE 9050
+EXPOSE 9050 9061
 
 RUN apt-get update && \
     apt-get install -y cpanminus && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y libnet-ssleay-perl && \
+    apt-get install -y libcrypt-ssleay-perl && \
+    apt-get install -y tor && \
+    apt-get install -y iptables && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cpanm --installdeps .
-RUN perl nipe.pl install
+
+RUN chmod +x nipe.pl
+
+# docker run -d -it --privileged --cap-add=NET_ADMIN nipe
+# OR
+# docker run -d -it --name nipe-container --privileged --cap-add=NET_ADMIN nipe
+# THEN
+# docker exec -it <container_id> ./nipe.pl <command>
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
- added EXPOSE 9061 for additional port
- installed required dependencies: libssl-dev, libnet-ssleay-perl, libcrypt-ssleay-perl, tor, iptables
- added execution permission to nipe.pl
- changed ENTRYPOINT to /bin/bash to keep the container running in the background