### PR TITLE
draft idea to fix issues

### DIFF
--- a/lib/Nipe/Engine/Start.pm
+++ b/lib/Nipe/Engine/Start.pm
@@ -2,6 +2,7 @@ package Nipe::Engine::Start {
 	use strict;
 	use warnings;
 	use Nipe::Utils::Device;
+	use Nipe::Utils::Status;
 
 	our $VERSION = '0.0.2';
 
@@ -72,8 +73,14 @@ package Nipe::Engine::Start {
 
 		system 'sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null';
 		system 'sysctl -w net.ipv6.conf.default.disable_ipv6=1 >/dev/null';
+		
+		my $status = Nipe::Utils::Status -> new();
+		
+		if ($status =~ /true/) {
+			return 1;
+		}
 
-		return 1;
+		return Engine::Restart -> new();
 	}
 }
 


### PR DESCRIPTION
This update adds a Status check at the end of the Start process. If the check returns success, Nipe is terminated, if not, a restart (stop and start) of the service is performed. This way, the start should be guaranteed to work.