### PR TITLE
status: verify TLS on the check.torproject.org request

### DIFF
--- a/lib/Nipe/Component/Utils/Status.pm
+++ b/lib/Nipe/Component/Utils/Status.pm
@@ -7,11 +7,11 @@ package Nipe::Component::Utils::Status {
 
 	Readonly my $SUCCESS_CODE => 200;
 
-	our $VERSION = '0.0.4';
+	our $VERSION = '0.0.5';
 
 	sub new {
 		my $api_check = 'https://check.torproject.org/api/ip';
-		my $request  = HTTP::Tiny -> new -> get($api_check);
+		my $request   = HTTP::Tiny -> new(verify_SSL => 1) -> get($api_check);
 
 		if ($request -> {status} == $SUCCESS_CODE) {
 			my $data = decode_json($request -> {content});

--- a/tests/status.t
+++ b/tests/status.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockModule;
+
+use lib './lib';
+
+BEGIN {
+    use_ok('Nipe::Component::Utils::Status');
+}
+
+my $http_mock = Test::MockModule -> new('HTTP::Tiny');
+
+subtest 'reports tor when IsTor is true' => sub {
+    plan tests => 2;
+
+    $http_mock -> mock('get', sub {
+        return { status => 200, content => '{"IsTor":true,"IP":"185.220.101.1"}' };
+    });
+
+    my $output = Nipe::Component::Utils::Status -> new();
+    ok(index($output, 'Status: true') >= 0,    'status is true');
+    ok(index($output, '185.220.101.1') >= 0,   'ip is shown');
+};
+
+subtest 'reports not tor when IsTor is false' => sub {
+    plan tests => 1;
+
+    $http_mock -> mock('get', sub {
+        return { status => 200, content => '{"IsTor":false,"IP":"8.8.8.8"}' };
+    });
+
+    my $output = Nipe::Component::Utils::Status -> new();
+    ok(index($output, 'Status: false') >= 0, 'status is false');
+};
+
+subtest 'reports an error when the request fails' => sub {
+    plan tests => 1;
+
+    $http_mock -> mock('get', sub {
+        return { status => 599, content => q{} };
+    });
+
+    my $output = Nipe::Component::Utils::Status -> new();
+    ok(index($output, 'not possible to establish a connection') >= 0, 'error branch');
+};
+
+done_testing();


### PR DESCRIPTION
### What was a problem?

`HTTP::Tiny->new` defaults to `verify_SSL => 0`, so the status check accepted any certificate. A tor exit, or anyone on the path, could return a forged `{"IsTor":true}` and nipe would report you as protected when you were not.

### How this PR fixes the problem?

Turn on `verify_SSL` for the check.torproject.org request. `IO::Socket::SSL` is already a declared dependency. The response formatting is split into a pure `format_status` so the output contract is testable without a network call.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

`t/30-status.t` covers the tor, non-tor and error branches.
